### PR TITLE
Add macOS system and app preferences

### DIFF
--- a/macos/.macos
+++ b/macos/.macos
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# ~/.macos — Based on https://mths.be/macos
+
+# Close any open System Preferences panes
+osascript -e 'tell application "System Preferences" to quit'
+
+# Ask for the administrator password upfront
+sudo -v
+
+# Keep-alive: update existing `sudo` time stamp until `.macos` has finished
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
+./.macos-prefs/system.sh
+./.macos-prefs/input.sh
+./.macos-prefs/sound.sh
+./.macos-prefs/desktop.sh
+./.macos-prefs/finder.sh
+
+# Kill affected applications
+for app in "Activity Monitor" \
+    "Address Book" \
+    "Calendar" \
+    "cfprefsd" \
+    "Contacts" \
+    "Dock" \
+    "Finder" \
+    "Mail" \
+    "Messages" \
+    "Photos" \
+    "Safari" \
+    "Spectacle" \; do
+    killall "${app}" &> /dev/null
+done
+
+echo "Done. Note that some of these changes require a logout/restart to take effect."

--- a/macos/.macos-prefs/desktop.sh
+++ b/macos/.macos-prefs/desktop.sh
@@ -1,0 +1,54 @@
+# - Display -
+
+# Enable subpixel font rendering on non-Apple LCDs
+# Reference: https://github.com/kevinSuttle/macOS-Defaults/issues/17#issuecomment-266633501
+defaults write NSGlobalDomain AppleFontSmoothing -int 1
+
+# - Menu Bar -
+
+# Hide the Time Machine, Volume, and User items
+for domain in ~/Library/Preferences/ByHost/com.apple.systemuiserver.*; do
+    defaults write "${domain}" dontAutoLoad -array \
+        "/System/Library/CoreServices/Menu Extras/TimeMachine.menu" \
+        "/System/Library/CoreServices/Menu Extras/Volume.menu" \
+        "/System/Library/CoreServices/Menu Extras/User.menu"
+done
+
+# Show Bluetooth, AirPort, Battery, and Clock
+defaults write com.apple.systemuiserver menuExtras -array \
+    "/System/Library/CoreServices/Menu Extras/Bluetooth.menu" \
+    "/System/Library/CoreServices/Menu Extras/AirPort.menu" \
+    "/System/Library/CoreServices/Menu Extras/Battery.menu" \
+    "/System/Library/CoreServices/Menu Extras/Clock.menu"
+
+# - Dock -
+
+# Change minimize/maximize window effect
+defaults write com.apple.dock mineffect -string "scale"
+
+# Set Dock orientation
+defaults write com.apple.dock orientation -string "left"
+
+# Automatically hide and show the Dock
+defaults write com.apple.dock autohide -bool true
+
+# Remove the auto-hiding Dock delay
+defaults write com.apple.dock autohide-delay -float 0
+
+# Set the icon size of Dock items to 36 pixels
+defaults write com.apple.dock tilesize -int 36
+
+# Don't animate opening applications from the Dock
+defaults write com.apple.dock launchanim -bool false
+
+# Show indicator lights for open applications in the Dock
+defaults write com.apple.dock show-process-indicators -bool true
+
+# Minimise apps to Dock icon
+defaults write com.apple.dock minimize-to-application -float 1
+
+# Remove the Dock recents section
+defaults write com.apple.dock show-recents -float 0
+
+# Disable the Launchpad gesture
+defaults write com.apple.dock showLaunchpadGestureEnabled -int 0

--- a/macos/.macos-prefs/finder.sh
+++ b/macos/.macos-prefs/finder.sh
@@ -1,0 +1,21 @@
+# Show all filename extensions
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+
+# Show path bar
+defaults write com.apple.finder ShowPathbar -bool true
+
+# Show the ~/Library folder
+chflags nohidden ~/Library
+
+# Avoid creating .DS_Store files on network or USB volumes
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+
+# When performing a search, search the current folder by default
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+
+# Disable the warning when changing a file extension
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+
+# Disable the warning before emptying the Trash
+defaults write com.apple.finder WarnOnEmptyTrash -bool false

--- a/macos/.macos-prefs/input.sh
+++ b/macos/.macos-prefs/input.sh
@@ -1,0 +1,42 @@
+# - Keyboard -
+
+# Enable full keyboard access for all controls
+defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
+
+# Disable press-and-hold for keys in favor of key repeat
+defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+
+# Reduce keyboard repeat rate
+defaults write NSGlobalDomain KeyRepeat -int 1
+defaults write NSGlobalDomain InitialKeyRepeat -int 10
+
+# Disable automatic capitalisation
+defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+
+# Disable smart dashes
+defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+
+# Disable automatic period substitution
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+
+# Disable smart quotes
+defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+
+# Disable auto-correct
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+
+# - Trackpad -
+
+# Disable "Natural" scroll direction
+defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
+
+# Map bottom right corner to right-click
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadCornerSecondaryClick -int 2
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadRightClick -bool true
+defaults -currentHost write NSGlobalDomain com.apple.trackpad.trackpadCornerClickBehavior -int 1
+defaults -currentHost write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true
+
+# - Devices -
+
+# Prevent Photos from opening automatically when devices are plugged in
+defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true

--- a/macos/.macos-prefs/input.sh
+++ b/macos/.macos-prefs/input.sh
@@ -3,6 +3,9 @@
 # Enable full keyboard access for all controls
 defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
 
+# Disable the keyboard focus ring animation
+defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
+
 # Disable press-and-hold for keys in favor of key repeat
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 

--- a/macos/.macos-prefs/sound.sh
+++ b/macos/.macos-prefs/sound.sh
@@ -1,0 +1,5 @@
+# Disable sound effects on boot
+sudo nvram SystemAudioV
+
+# Stop iTunes from responding to the keyboard media keys
+launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist 2> /dev/nullolume=" "

--- a/macos/.macos-prefs/system.sh
+++ b/macos/.macos-prefs/system.sh
@@ -1,0 +1,25 @@
+# Reveal IP address, hostname, OS version, etc. when clicking the clock in the
+# login window
+sudo defaults write /Library/Preferences/com.apple.loginwindow AdminHostInfo HostName
+
+# Restart automatically if the computer freezes
+sudo systemsetup -setrestartfreeze on
+
+# Disable Resume system-wide
+defaults write com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false
+
+# Disable automatic termination of inactive apps
+defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true
+
+# Require password immediately after sleep or screen saver begins
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int 0
+
+# Save to disk (not to iCloud) by default
+defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+
+# Disable the "Are you sure you want to open this application?" dialog
+defaults write com.apple.LaunchServices LSQuarantine -bool false
+
+# Automatically quit printer app once the print jobs complete
+defaults write com.apple.print.PrintingPrefs "Quit When Finished" -bool true

--- a/spectacle/Library/Application Support/Spectacle/Shortcuts.json
+++ b/spectacle/Library/Application Support/Spectacle/Shortcuts.json
@@ -1,0 +1,74 @@
+[
+  {
+    "shortcut_key_binding" : "alt+shift+cmd+z",
+    "shortcut_name" : "RedoLastMove"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MakeSmaller"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MoveToUpperLeft"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MoveToUpperRight"
+  },
+  {
+    "shortcut_key_binding" : "ctrl+alt+cmd+down",
+    "shortcut_name" : "MoveToBottomHalf"
+  },
+  {
+    "shortcut_key_binding" : "ctrl+alt+cmd+right",
+    "shortcut_name" : "MoveToNextDisplay"
+  },
+  {
+    "shortcut_key_binding" : "ctrl+alt+cmd+up",
+    "shortcut_name" : "MoveToTopHalf"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MoveToLowerLeft"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MakeLarger"
+  },
+  {
+    "shortcut_key_binding" : "alt+cmd+z",
+    "shortcut_name" : "UndoLastMove"
+  },
+  {
+    "shortcut_key_binding" : "ctrl+alt+cmd+left",
+    "shortcut_name" : "MoveToPreviousDisplay"
+  },
+  {
+    "shortcut_key_binding" : "alt+cmd+up",
+    "shortcut_name" : "MoveToFullscreen"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MoveToNextThird"
+  },
+  {
+    "shortcut_key_binding" : "alt+cmd+left",
+    "shortcut_name" : "MoveToLeftHalf"
+  },
+  {
+    "shortcut_key_binding" : "alt+cmd+c",
+    "shortcut_name" : "MoveToCenter"
+  },
+  {
+    "shortcut_key_binding" : "alt+cmd+right",
+    "shortcut_name" : "MoveToRightHalf"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MoveToPreviousThird"
+  },
+  {
+    "shortcut_key_binding" : null,
+    "shortcut_name" : "MoveToLowerRight"
+  }
+]

--- a/vim/.vim/plugins.vim
+++ b/vim/.vim/plugins.vim
@@ -3,6 +3,7 @@ call plug#begin('~/.vim/plugged')
 Plug 'airblade/vim-gitgutter'
 Plug 'bronson/vim-trailing-whitespace'
 Plug 'dag/vim-fish'
+Plug 'darfink/vim-plist'
 Plug 'easymotion/vim-easymotion'
 Plug 'editorconfig/editorconfig-vim'
 Plug 'itchyny/lightline.vim'


### PR DESCRIPTION
This adds a wide-spanning set of base preferences for macOS as a `~/.macos` script, based on https://mths.be/macos, and includes the `Shortcuts.json` configuration file for the [Spectacle](https://www.spectacleapp.com/) keyboard window management utility.