### PR TITLE
Enable auto mode for Claude Code by default

### DIFF
--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -52,7 +52,7 @@ abbr -a nvm fnm
 
 alias sail './vendor/bin/sail'
 
-alias claude 'command claude --enable-auto-mode'
+abbr -a claude 'claude --enable-auto-mode'
 
 alias explain 'gh copilot explain'
 alias suggest 'gh copilot suggest'

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -52,6 +52,8 @@ abbr -a nvm fnm
 
 alias sail './vendor/bin/sail'
 
+alias claude 'command claude --enable-auto-mode'
+
 alias explain 'gh copilot explain'
 alias suggest 'gh copilot suggest'
 

--- a/tmux/.tmux-devserver-setup.sh
+++ b/tmux/.tmux-devserver-setup.sh
@@ -7,5 +7,5 @@ PANE_COUNT=$(tmux list-panes | wc -l)
 
 if [ "$WINDOW_COUNT" -eq 1 ] && [ "$PANE_COUNT" -eq 1 ]; then
     # Change to fbsource and start claude in the current pane
-    tmux send-keys 'exec fish -lc "cd ~/fbsource && exec claude"' C-m
+    tmux send-keys 'exec fish -lc "cd ~/fbsource && exec claude --enable-auto-mode"' C-m
 fi

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -83,7 +83,7 @@
   "zenMode.restore": false,
   // #endregion
   // #region Extensions
-  "claudeCode.initialPermissionMode": "acceptEdits",
+  "claudeCode.initialPermissionMode": "auto",
   "claudeCode.preferredLocation": "sidebar",
   "fileutils.newFile.typeahead.enabled": false,
   "fileutils.newFolder.typeahead.enabled": false,


### PR DESCRIPTION
Add --enable-auto-mode flag to tmux devserver launch, VS Code initial
permission mode, and a fish alias so auto mode is active everywhere.

https://claude.ai/code/session_018qiRQA2ugSm8511Pw7egtQ